### PR TITLE
Support SLT/SLTU instructions.

### DIFF
--- a/bench/verilog/polaris.v
+++ b/bench/verilog/polaris.v
@@ -429,6 +429,45 @@ module PolarisCPU_tb();
 		tick(64);
 		assert_istb(1);
 		assert_iadr(64'hFFFF_FFFF_8000_0000);
+
+		// Bug https://github.com/KestrelComputer/polaris/issues/18
+		idat_i <= 32'b111111111111_00000_000_00001_0010011;	// ADDI X1, X0, -1
+		tick(100);
+		tick(101);
+		tick(102);
+		tick(103);
+		idat_i <= 32'b000000000001_00001_010_00010_0010011;	// SLTI X2, X1, 1
+		tick(105);
+		tick(106);
+		tick(107);
+		tick(108);
+		idat_i <= 32'b000000000000_00010_000_00000_1100111;	// JALR 0, 0(2)
+		tick(110);
+		tick(111);
+		tick(112);
+		tick(113);
+		tick(114);
+		assert_istb(1);
+		assert_iadr(64'h0000_0000_0000_0001);
+
+		idat_i <= 32'b111111111111_00000_000_00001_0010011;	// ADDI X1, X0, -1
+		tick(100);
+		tick(101);
+		tick(102);
+		tick(103);
+		idat_i <= 32'b000000000001_00001_011_00010_0010011;	// SLTUI X2, X1, 1
+		tick(105);
+		tick(106);
+		tick(107);
+		tick(108);
+		idat_i <= 32'b000000000000_00010_000_00000_1100111;	// JALR 0, 0(2)
+		tick(110);
+		tick(111);
+		tick(112);
+		tick(113);
+		tick(114);
+		assert_istb(1);
+		assert_iadr(64'h0000_0000_0000_0000);
 	end
 	endtask
 

--- a/rtl/verilog/alu.v
+++ b/rtl/verilog/alu.v
@@ -28,7 +28,9 @@ module alu(
 	wire [63:0] sumL = inA_i[62:0] + b[62:0] + {62'b0, cflag_i};
 	wire c62 = sumL[63];
 	wire [64:63] sumH = inA_i[63] + b[63] + c62;
-	wire [63:0] sums = sum_en_i ? {sumH[63], sumL[62:0]} : 64'd0;
+	wire [63:0] rawSums = {sumH[63], sumL[62:0]};
+
+	wire [63:0] sums = sum_en_i ? rawSums : 64'd0;
 	assign zflag_o = ~(|out_o);
 	assign vflag_o = sumH[64] ^ sumL[63];
 	assign cflag_o = sumH[64];
@@ -59,5 +61,8 @@ module alu(
 	wire [63:0] rsh1  = inB_i[0] ? {sx0, rsh2[63:1]} : rsh2;
 	wire [63:0] rshs = rsh_en_i ? rsh1 : 0;
 
-	assign out_o = sums | ands | xors | lshs | rshs ;
+	wire isLTS = lts_en_i ? {63'd0, rawSums[63] ^ vflag_o} : 0;
+	wire isLTU = ltu_en_i ? {63'd0, ~cflag_o} : 0;
+
+	assign out_o = sums | ands | xors | lshs | rshs | isLTS | isLTU;
 endmodule


### PR DESCRIPTION
These instructions were previously missing.  They're back!
Fixes #18